### PR TITLE
[FIX] 로그인 저장 로직 수정

### DIFF
--- a/OnlyOne/Source/OnlyOne/Private/Controllers/POMainMenuPlayerController.cpp
+++ b/OnlyOne/Source/OnlyOne/Private/Controllers/POMainMenuPlayerController.cpp
@@ -8,6 +8,7 @@
 #include "Framework/Application/SlateApplication.h"
 #include "OnlyOne/OnlyOne.h"
 #include "UI/MainMenu/POJoinServerWidget.h"
+#include "Game/POGameInstance.h"
 
 APOMainMenuPlayerController::APOMainMenuPlayerController()
 {
@@ -73,4 +74,9 @@ void APOMainMenuPlayerController::ShowJoinServer()
 void APOMainMenuPlayerController::OnJoinServer(const FJoinServerData& JoinServerData)
 {
 	UE_LOG(POLog, Log, TEXT("OnJoinServer : Name=%s, IPAddress=%s"), *JoinServerData.Name, *JoinServerData.IPAddress);
+
+	if (UPOGameInstance* GI = GetGameInstance<UPOGameInstance>())
+	{
+		GI->SetPendingProfile(JoinServerData.Name, JoinServerData.IPAddress);
+	}
 }

--- a/OnlyOne/Source/OnlyOne/Private/Controllers/POServerLobbyPlayerController.cpp
+++ b/OnlyOne/Source/OnlyOne/Private/Controllers/POServerLobbyPlayerController.cpp
@@ -5,6 +5,7 @@
 
 #include "Blueprint/UserWidget.h"
 #include "UI/ServerLobbyMenu/POServerLobbyWidget.h"
+#include "game/POLobbyPlayerState.h"
 
 void APOServerLobbyPlayerController::BeginPlay()
 {
@@ -13,6 +14,19 @@ void APOServerLobbyPlayerController::BeginPlay()
 	if (IsLocalPlayerController())
 	{
 		ShowLobbyWidget();
+	}
+}
+
+void APOServerLobbyPlayerController::OnRep_PlayerState()
+{
+	Super::OnRep_PlayerState();
+
+	if (IsLocalPlayerController())
+	{
+		if (APOLobbyPlayerState* PS = GetPlayerState<APOLobbyPlayerState>())
+		{
+			PS->InitNicknameFromGameInstanceOnce();
+		}
 	}
 }
 

--- a/OnlyOne/Source/OnlyOne/Private/Game/POLobbyPlayerState.cpp
+++ b/OnlyOne/Source/OnlyOne/Private/Game/POLobbyPlayerState.cpp
@@ -13,7 +13,6 @@ APOLobbyPlayerState::APOLobbyPlayerState()
 void APOLobbyPlayerState::BeginDestroy()
 {
 	OnReadyChanged.Clear();
-	OnNicknameReady.Clear();
 	Super::BeginDestroy();
 }
 
@@ -50,7 +49,6 @@ void APOLobbyPlayerState::ServerSetNicknameOnce_Implementation(const FString& In
 	BaseNickname    = Base;
 	DisplayNickname = FString::Printf(TEXT("%s%s"), *Base, *TagStr);
 
-	OnRep_DisplayNickname();
 }
 
 void APOLobbyPlayerState::ServerSetReady_Implementation(bool bInReady)
@@ -65,11 +63,6 @@ void APOLobbyPlayerState::ServerSetReady_Implementation(bool bInReady)
 void APOLobbyPlayerState::OnRep_IsReady()
 {
 	OnReadyChanged.Broadcast(bIsReady);
-}
-
-void APOLobbyPlayerState::OnRep_DisplayNickname()
-{
-	OnNicknameReady.Broadcast(DisplayNickname);
 }
 
 void APOLobbyPlayerState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const

--- a/OnlyOne/Source/OnlyOne/Public/Controllers/POServerLobbyPlayerController.h
+++ b/OnlyOne/Source/OnlyOne/Public/Controllers/POServerLobbyPlayerController.h
@@ -30,6 +30,8 @@ public:
 protected:
 	virtual void BeginPlay() override;
 
+	virtual void OnRep_PlayerState() override;
+
 	UPROPERTY(EditDefaultsOnly)
 	TSubclassOf<UPOServerLobbyWidget> ServerLobbyWidgetClass;
 

--- a/OnlyOne/Source/OnlyOne/Public/Game/POLobbyPlayerState.h
+++ b/OnlyOne/Source/OnlyOne/Public/Game/POLobbyPlayerState.h
@@ -7,7 +7,6 @@
 #include "POLobbyPlayerState.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FPOOnReadyChanged, bool, bNowReady);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FPOOnNicknameReady, const FString&, DisplayNickname);
 
 /**
  * 
@@ -39,9 +38,6 @@ public:
 	UPROPERTY(BlueprintAssignable, Category="PO|Lobby")
 	FPOOnReadyChanged OnReadyChanged;
 
-	UPROPERTY(BlueprintAssignable, Category="PO|Lobby")
-	FPOOnNicknameReady OnNicknameReady;
-
 public:
 	UFUNCTION(Server, Reliable)
 	void ServerSetNicknameOnce(const FString& InNickname);
@@ -53,9 +49,6 @@ public:
 	UFUNCTION()
 	void OnRep_IsReady();
 
-	UFUNCTION()
-	void OnRep_DisplayNickname();
-
 protected:
 	UPROPERTY(ReplicatedUsing=OnRep_IsReady)
 	bool bIsReady;
@@ -63,7 +56,7 @@ protected:
 	UPROPERTY(Replicated)
 	FString BaseNickname;
 	
-	UPROPERTY(ReplicatedUsing=OnRep_DisplayNickname)
+	UPROPERTY(Replicated)
 	FString DisplayNickname;
 
 protected:


### PR DESCRIPTION
# Pull Request

## 주요 변경사항
- 로그인 정보 저장 로직 변경 및 추가
- 닉네임 관련 델리게이트/RepNotify는 미사용(삭제)

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #
- Related to #

## 테스트 방법
1. 
2. 
3. 

## 📷 스크린샷 (선택사항)
<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

## ⚠️ 주의사항
<!-- 리뷰어가 특별히 확인해야 할 부분이나 주의사항이 있다면 작성해주세요 -->

## 📋 체크리스트
<!-- PR 제출 전 확인사항 -->
- [x] 코드가 프로젝트의 스타일 가이드를 따르고 있습니다
- [x] 자체 검토를 수행했습니다
- [x] 불필요한 주석과 테스트 용 코드를 제거했습니다
- [ ] 모든 테스트가 통과합니다

## 📝 추가 정보
<!-- 기타 리뷰어에게 전달하고 싶은 내용이 있다면 작성해주세요 -->
APOMainMenuPlayerController::OnJoinServer()에서 입력받은 정보를 GameInstance에 저장하도록 구현했습니다. 
그러므로 정보 저장 이후 레벨 이동을 부탁드리겠습니다.

닉네임은 최초 1회 확정 후 변경되지 않는 것을 전제로 이벤트 및 RepNotify를 제거하고, 단순 복제로만 유지했습니다.

반면 레디 상태는 실시간으로 변동될 수 있으므로 델리게이트를 유지했습니다. 다만 UI 바인딩 범위에 따라 상태 변경 시 전체 UI가 갱신되는 상황이 생길 수 있으니, 필요에 따라 적절히 활용해 주시고, 불필요하다면 추후 삭제하겠습니다.