### PR TITLE
[ADD] 로비 게임시작 조건 구현

### DIFF
--- a/OnlyOne/Source/OnlyOne/Private/Controllers/POMainMenuPlayerController.cpp
+++ b/OnlyOne/Source/OnlyOne/Private/Controllers/POMainMenuPlayerController.cpp
@@ -105,7 +105,7 @@ void APOMainMenuPlayerController::OnJoinServer(FJoinServerData& JoinServerData)
 	
 	if (UPOGameInstance* GI = GetGameInstance<UPOGameInstance>())
 	{
-		GI->SetPendingProfile(JoinServerData.Name, JoinServerData.IPAddress);
+		GI->SetPendingProfile(JoinServerData);
 	}
 	
 	FString TravelURL = JoinServerData.IPAddress;
@@ -132,7 +132,7 @@ void APOMainMenuPlayerController::OnHostServer(FJoinServerData& HostServerData)
 {
 	if (UPOGameInstance* GI = GetGameInstance<UPOGameInstance>())
 	{
-		GI->SetPendingProfile(HostServerData.Name, HostServerData.IPAddress);
+		GI->SetPendingProfile(HostServerData);
 	}
 	
 	if (UWorld* World = GetWorld())

--- a/OnlyOne/Source/OnlyOne/Private/Game/POLobbyGameState.cpp
+++ b/OnlyOne/Source/OnlyOne/Private/Game/POLobbyGameState.cpp
@@ -1,7 +1,34 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 #include "game/POLobbyGameState.h"
+#include "Net/UnrealNetwork.h"
 
 APOLobbyGameState::APOLobbyGameState()
 {
+	CountdownRemaining = 0;
+	bAllReady = false;
+}
+
+void APOLobbyGameState::SetCountdownRemaining(int32 InRemaining)
+{
+	if (HasAuthority())
+	{
+		CountdownRemaining = InRemaining;
+	}
+}
+
+void APOLobbyGameState::SetAllReady(bool bInAllReady)
+{
+	if (HasAuthority())
+	{
+		bAllReady = bInAllReady;
+	}
+}
+
+void APOLobbyGameState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME(APOLobbyGameState, CountdownRemaining);
+	DOREPLIFETIME(APOLobbyGameState, bAllReady);
 }

--- a/OnlyOne/Source/OnlyOne/Private/Game/POLobbyPlayerState.cpp
+++ b/OnlyOne/Source/OnlyOne/Private/Game/POLobbyPlayerState.cpp
@@ -3,6 +3,7 @@
 #include "game/POLobbyPlayerState.h"
 
 #include "Controllers/POServerLobbyPlayerController.h"
+#include "Controllers/POMainMenuPlayerController.h"
 #include "Net/UnrealNetwork.h"
 #include "game/POGameInstance.h"
 #include "game/POBadWords.h"
@@ -55,7 +56,7 @@ void APOLobbyPlayerState::InitNicknameFromGameInstanceOnce()
 {
 	if (UPOGameInstance* GI = GetGameInstance<UPOGameInstance>())
 	{
-		const FString NickFromGI = GI->GetPendingNickname();
+		const FString NickFromGI = GI->GetPendingProfile().Name;
 		ServerSetNicknameOnce(NickFromGI);
 		LOG_NET(POLog, Warning, TEXT("Player %d nickname initialized from GI: %s"), GetPlayerId(), *BaseNickname);
 	}

--- a/OnlyOne/Source/OnlyOne/Public/Game/POGameInstance.h
+++ b/OnlyOne/Source/OnlyOne/Public/Game/POGameInstance.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Engine/GameInstance.h"
+#include "Controllers/POMainMenuPlayerController.h"
 #include "POGameInstance.generated.h"
 
 /**
@@ -18,23 +19,20 @@ class ONLYONE_API UPOGameInstance : public UGameInstance
 public:
 
 	//TODO: 닉네임과 서버주소를 FJoinServerData와 통합하도록 변경해주세요.
-	UFUNCTION(BlueprintCallable, Category="PO|Profile")
-	void SetPendingProfile(const FString& InNickname, const FString& InServerAddress)
+	UFUNCTION(Category="PO|Profile")
+	void SetPendingProfile(FJoinServerData& InitUserData)
 	{
-		PendingNickname = InNickname;
-		PendingServerAddress = InServerAddress;
+		JoinServerData = InitUserData;
 	}
 	
-	UFUNCTION(BlueprintPure, Category="PO|Profile")
-	const FString& GetPendingNickname() const { return PendingNickname; }
-
-	UFUNCTION(BlueprintPure, Category="PO|Profile")
-	const FString& GetPendingServerAddress() const { return PendingServerAddress; }
+	UFUNCTION(Category="PO|Profile")
+	const FJoinServerData& GetPendingProfile() const
+	{
+		return JoinServerData;
+	}
 
 private:
 	UPROPERTY()
-	FString PendingNickname;
+	FJoinServerData JoinServerData;
 
-	UPROPERTY()
-	FString PendingServerAddress;
 };

--- a/OnlyOne/Source/OnlyOne/Public/Game/POLobbyGameMode.h
+++ b/OnlyOne/Source/OnlyOne/Public/Game/POLobbyGameMode.h
@@ -22,11 +22,30 @@ public:
 	
 	virtual void PreLogin(const FString& Options, const FString& Address, const FUniqueNetIdRepl& UniqueId, FString& ErrorMessage) override;
 	virtual void InitGame(const FString& MapName, const FString& Options, FString& ErrorMessage) override;
-
 	virtual void PostLogin(APlayerController* NewPlayer) override;
 	virtual void Logout(AController* Exiting) override;
 
 public:
+	void NotifyReadyStateChanged(APOLobbyPlayerState* ChangedPlayer, bool bNowReady);
+
+protected:
+	bool AreAllPlayersReady() const;
+	
+	void TryStartCountdown();
+	void CancelCountdown(const TCHAR* Reason);
+	void TickCountdown();
+	void OnCountdownFinished();
+	
+protected:
+	FTimerHandle StartMatchTimerHandle;
+	int32 CountdownRemaining;
+
 	UPROPERTY(EditDefaultsOnly, Category="PO|Lobby", meta=(ClampMin="2", ClampMax="16", UIMin="2", UIMax="16"))
 	int32 MaxPlayersInLobby;
+
+	UPROPERTY(EditDefaultsOnly, Category="PO|Lobby", meta=(ClampMin="1", ClampMax="60", UIMin="1", UIMax="30"))
+	int32 CountdownSecondsDefault;
+
+	bool bCountdownRunning;
+	
 };

--- a/OnlyOne/Source/OnlyOne/Public/Game/POLobbyGameState.h
+++ b/OnlyOne/Source/OnlyOne/Public/Game/POLobbyGameState.h
@@ -16,4 +16,21 @@ class ONLYONE_API APOLobbyGameState : public AGameState
 
 public:
 	APOLobbyGameState();
+
+public:
+	int32 GetCountdownRemaining() const { return CountdownRemaining; }
+	bool IsAllReady() const { return bAllReady; }
+	
+	void SetCountdownRemaining(int32 InRemaining);
+	void SetAllReady(bool bInAllReady);
+
+protected:
+	UPROPERTY(Replicated)
+	int32 CountdownRemaining;
+
+	UPROPERTY(Replicated)
+	bool bAllReady;
+
+public:
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 };

--- a/OnlyOne/Source/OnlyOne/Public/Game/POLobbyPlayerState.h
+++ b/OnlyOne/Source/OnlyOne/Public/Game/POLobbyPlayerState.h
@@ -7,9 +7,6 @@
 #include "GameFramework/PlayerState.h"
 #include "POLobbyPlayerState.generated.h"
 
-//DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FPOOnReadyChanged, bool, bNowReady);
-//DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnInitalizedPlayerData, const FJoinServerData&, PlayerData);
-
 /**
  * 
  */
@@ -40,14 +37,6 @@ public:
 
 	UFUNCTION(BlueprintPure, Category="PO|Lobby")
 	const FString& GetDisplayNickname() const { return DisplayNickname; }
-
-	// 더 이상 사용되지 않음
-	//UPROPERTY(BlueprintAssignable, Category="PO|Lobby")
-	//FPOOnReadyChanged OnReadyChanged;
-
-	// 더 이상 사용되지 않음
-	//UPROPERTY(BlueprintAssignable, Category="PO|Lobby")
-	//FOnInitalizedPlayerData OnInitalizedPlayerData;
 
 	UFUNCTION(BlueprintCallable, Category="PO|Lobby")
 	void ToggleReady();


### PR DESCRIPTION
# Pull Request

## 주요 변경사항
- 로비에서 전원 레디 시 5초 카운트다운이 시작되도록 로직 추가
- 카운트다운 중 플레이어 입장/퇴장/레디 해제/강종 발생 시 즉시 카운트다운 취소 및 재평가
- AreAllPlayersReady()에 최소 2인 이상 조건 추가 (1명일 때는 시작 불가)

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #
- Related to #

## 테스트 방법
1. 모두 Ready 클릭 → 서버 로그에서 카운트다운 시작 → 5초 후 완료 로그 확인
2. 도중에 한 플레이어 Ready 해제/퇴장 → 카운트다운 취소 로그 확인
3. 전원 Ready 다시 시도 → 카운트다운이 5초부터 재시작 확인
4. 1명만 Ready일 때는 카운트다운 시작되지 않는 것 확인

## 📷 스크린샷 (선택사항)
<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

## ⚠️ 주의사항
<!-- 리뷰어가 특별히 확인해야 할 부분이나 주의사항이 있다면 작성해주세요 -->

## 📋 체크리스트
<!-- PR 제출 전 확인사항 -->
- [x] 코드가 프로젝트의 스타일 가이드를 따르고 있습니다
- [x] 자체 검토를 수행했습니다
- [x] 불필요한 주석과 테스트 용 코드를 제거했습니다
- [x] 모든 테스트가 통과합니다

## 📝 추가 정보
<!-- 기타 리뷰어에게 전달하고 싶은 내용이 있다면 작성해주세요 -->
현재는 로그 출력만으로 게임 시작을 검증합니다. 실제 레벨 이동(ServerTravel)은 추후 연결 예정입니다.
