### PR TITLE
[ADD] PlayerState 초기화 및 상태 변경 델리게이트 브로드캐스트

### DIFF
--- a/OnlyOne/Source/OnlyOne/Private/Game/POLobbyPlayerState.cpp
+++ b/OnlyOne/Source/OnlyOne/Private/Game/POLobbyPlayerState.cpp
@@ -4,6 +4,7 @@
 
 #include "Controllers/POServerLobbyPlayerController.h"
 #include "Controllers/POMainMenuPlayerController.h"
+#include "Controllers/POPlayerController.h"
 #include "Net/UnrealNetwork.h"
 #include "game/POGameInstance.h"
 #include "game/POBadWords.h"
@@ -120,6 +121,7 @@ void APOLobbyPlayerState::ServerSetNicknameOnce_Implementation(const FString& In
 		UE_LOG(POLog, Warning, TEXT("Player %d ServerSetNicknameOnce_Implementation: Base was empty, using default 'Player'"), GetPlayerId());
 	}
 	*/
+	
 	const FString Base = InNickname.IsEmpty() ? TEXT("Player") : InNickname;
 	const int32 Tag = GetPlayerId() % 10000;
 	const FString TagStr = FString::Printf(TEXT("#%04d"), Tag);
@@ -130,6 +132,7 @@ void APOLobbyPlayerState::ServerSetNicknameOnce_Implementation(const FString& In
 	LOG_NET(POLog, Warning, TEXT("Player %d set nickname: %s"), GetPlayerId(), *DisplayNickname);
 
 	MulticastPlayerJoinedLobby(BaseNickname);
+	OnRep_DisplayNickname();
 }
 
 void APOLobbyPlayerState::ServerSetReady_Implementation()
@@ -271,6 +274,31 @@ FString APOLobbyPlayerState::SanitizeNickname_Server(const FString& InRaw) const
 	return S;
 }
 
+void APOLobbyPlayerState::PushSnapshotToLocalUI() const
+{
+	if (DisplayNickname.IsEmpty())
+	{
+		return;
+	}
+
+	LOG_NET(POLog, Warning, TEXT("[PS] PushSnapshotToLocalUI -> Nick=%s, Alive=%s, Kill=%d, Id=%d"),
+	*DisplayNickname,
+	bIsAlive ? TEXT("true") : TEXT("false"),
+	KillScore,
+	GetPlayerId());
+
+	if (UWorld* World = GetWorld())
+	{
+		if (APlayerController* LocalPCBase = UGameplayStatics::GetPlayerController(World, 0))
+		{
+			if (APOPlayerController* LocalPC = Cast<APOPlayerController>(LocalPCBase))
+			{
+				LocalPC->OnSetPlayerStateEntry.Broadcast(DisplayNickname, bIsAlive, KillScore);
+			}
+		}
+	}
+}
+
 void APOLobbyPlayerState::ServerResetForMatchStart()
 {
 	if (!HasAuthority())
@@ -304,15 +332,28 @@ void APOLobbyPlayerState::ServerSetAlive_Implementation(bool bInAlive)
 	bIsAlive = bInAlive;
 	OnRep_IsAlive();
 }
+void APOLobbyPlayerState::OnRep_DisplayNickname()
+{
+	LOG_NET(POLog, Warning, TEXT("Player %d OnRep_DisplayNickname -> %s"),
+	GetPlayerId(), *DisplayNickname);
+	
+	PushSnapshotToLocalUI();
+}
 
 void APOLobbyPlayerState::OnRep_KillScore()
 {
-	// HUD/위젯 갱신 필요 시 브로드캐스트
+	LOG_NET(POLog, Warning, TEXT("Player %d OnRep_KillScore -> %d"),
+	GetPlayerId(), KillScore);
+	
+	PushSnapshotToLocalUI();
 }
 
 void APOLobbyPlayerState::OnRep_IsAlive()
 {
-	// 이름표 색상(사망시 회색) 등 갱신 필요 시 처리
+	LOG_NET(POLog, Warning, TEXT("Player %d OnRep_IsAlive -> %s"),
+	GetPlayerId(), bIsAlive ? TEXT("true") : TEXT("false"));
+	
+	PushSnapshotToLocalUI();
 }
 
 

--- a/OnlyOne/Source/OnlyOne/Private/Game/POStageGameMode.cpp
+++ b/OnlyOne/Source/OnlyOne/Private/Game/POStageGameMode.cpp
@@ -110,6 +110,22 @@ void APOStageGameMode::PostLogin(APlayerController* NewPlayer)
 	}
 }
 
+void APOStageGameMode::Logout(AController* Exiting)
+{
+	if (Exiting)
+	{
+		if (APOLobbyPlayerState* PS = Cast<APOLobbyPlayerState>(Exiting->PlayerState))
+		{
+			PS->ServerSetAlive(false);
+
+			LOG_NET(POLog, Warning, TEXT("[StageGM] Logout: Mark DEAD %s (Id=%d)"),
+				*PS->GetPlayerName(), PS->GetPlayerId());
+		}
+	}
+	
+	Super::Logout(Exiting);
+}
+
 UClass* APOStageGameMode::GetDefaultPawnClassForController_Implementation(AController* InController)
 {
 	return PlayerPawnClass

--- a/OnlyOne/Source/OnlyOne/Public/Game/POLobbyPlayerState.h
+++ b/OnlyOne/Source/OnlyOne/Public/Game/POLobbyPlayerState.h
@@ -74,6 +74,9 @@ protected:
 	void OnRep_IsReady();
 
 	UFUNCTION()
+	void OnRep_DisplayNickname();
+
+	UFUNCTION()
 	void OnRep_KillScore();
 
 	UFUNCTION()
@@ -87,7 +90,7 @@ protected:
 	UPROPERTY(Replicated)
 	FString BaseNickname;
 
-	UPROPERTY(Replicated)
+	UPROPERTY(ReplicatedUsing=OnRep_DisplayNickname)
 	FString DisplayNickname;
 
 	/* Stage Stats */
@@ -99,6 +102,7 @@ protected:
 
 private:
 	void InitializeExistingPlayers();
+	void PushSnapshotToLocalUI() const;
 	
 	FString SanitizeNickname_Server(const FString& InRaw) const;
 };

--- a/OnlyOne/Source/OnlyOne/Public/Game/POStageGameMode.h
+++ b/OnlyOne/Source/OnlyOne/Public/Game/POStageGameMode.h
@@ -45,6 +45,7 @@ protected:
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 	virtual void PostLogin(APlayerController* NewPlayer) override;
+	virtual void Logout(AController* Exiting) override;
 
 	virtual UClass* GetDefaultPawnClassForController_Implementation(AController* InController) override;
 	virtual AActor* ChoosePlayerStart_Implementation(AController* Player) override;


### PR DESCRIPTION
# Pull Request

## 주요 변경사항
- PlayerState가 생성될 때 최초 1회 델리게이트를 호출하도록 추가
- KillScore 또는 Alive 상태가 변경될 때마다 델리게이트를 브로드캐스트
- 

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #
- Related to #

## 테스트 방법
1.  PlayerState 생성 시 PushSnapshotToLocalUI 호출 로그 확인
2.  강제 종료시 OnRep_IsAlive → 로그 확인
3. 

## 📷 스크린샷 (선택사항)
<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

## ⚠️ 주의사항
<!-- 리뷰어가 특별히 확인해야 할 부분이나 주의사항이 있다면 작성해주세요 -->

## 📋 체크리스트
<!-- PR 제출 전 확인사항 -->
- [x] 코드가 프로젝트의 스타일 가이드를 따르고 있습니다
- [x] 자체 검토를 수행했습니다
- [x] 불필요한 주석과 테스트 용 코드를 제거했습니다
- [x] 모든 테스트가 통과합니다

## 📝 추가 정보
<!-- 기타 리뷰어에게 전달하고 싶은 내용이 있다면 작성해주세요 -->
Kill 발생 시 PlayerState 정보 변경(킬 카운트 증가 등)은 아직 게임 로직과 연동되지 않았습니다.
해당 부분은 추후 연동 작업 후 별도의 PR과 테스트를 통해 진행할 예정입니다.
