### PR TITLE
refactor: 사망처리 & 관전모드 로직 변경

### DIFF
--- a/OnlyOne/Source/OnlyOne/Private/Controllers/POPlayerController.cpp
+++ b/OnlyOne/Source/OnlyOne/Private/Controllers/POPlayerController.cpp
@@ -110,13 +110,8 @@ void APOPlayerController::BeginPlay()
 
 void APOPlayerController::StartSpectating(const APawn* DeadCharacter)
 {
-	if (!DeadCharacter)
-	{
-		return;		
-	}
-
-	// Pawn은 Destroy될 수 있으므로 PlayerState만 저장
-	DiedPlayerState = DeadCharacter->GetPlayerState();
+	// Pawn은 Destroy될 수 있으므로 PlayerState만 저장 & nullptr 허용
+	DiedPlayerState = DeadCharacter ? DeadCharacter->GetPlayerState() : nullptr;
 
 	PlayerState->SetIsSpectator(true);
 	ChangeState(NAME_Spectating);
@@ -149,7 +144,7 @@ void APOPlayerController::BuildSpectatorTargets()
 
 		// 캐릭터가 살아있는지, 그리고 방금 죽은 자기 자신이 아닌지 확인
 		const bool bIsAlive = TargetPlayerCharacter->GetPOAbilitySystemComponent() && !TargetPlayerCharacter->GetPOAbilitySystemComponent()->HasMatchingGameplayTag(POGameplayTags::Shared_Status_Death);
-		const bool bIsNotSelf = TargetPlayerCharacter->GetPlayerState() != DiedPlayerState;
+		const bool bIsNotSelf = !DiedPlayerState || TargetPlayerCharacter->GetPlayerState() != DiedPlayerState;
 
 		if (bIsAlive && bIsNotSelf)
 		{


### PR DESCRIPTION
# Pull Request

## 주요 변경사항
- 캐릭터가 죽었을때 누가 누구를 죽였는지 컨트롤러 정보를 `StageGameMode`로 전송하게 로직 수정하였습니다.
- 중간 합류자는 바로 관전모드로 진입하게 조건을 수정하였습니다
- 

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #
- Related to #

## 테스트 방법
1. 플레이어를 죽입니다
2. 킬 로그가 나오는지 확인합니다
  - 로그정보: `[StageGM] Kill++ : %s`, `[StageGM] Dead : %s, AliveNow=%d` 
3. 중간 합류했을때 관전모드로 가며, 바인딩된 `Q`, `E` 가 작동하는지 확인합니다

## 📷 스크린샷 (선택사항)
<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

## ⚠️ 주의사항
<!-- 리뷰어가 특별히 확인해야 할 부분이나 주의사항이 있다면 작성해주세요 -->

## 📋 체크리스트
<!-- PR 제출 전 확인사항 -->
- [ ] 코드가 프로젝트의 스타일 가이드를 따르고 있습니다
- [ ] 자체 검토를 수행했습니다
- [ ] 불필요한 주석과 테스트 용 코드를 제거했습니다
- [ ] 모든 테스트가 통과합니다

## 📝 추가 정보
<!-- 기타 리뷰어에게 전달하고 싶은 내용이 있다면 작성해주세요 -->
