### PR TITLE
[ADD] 특수 승리 트리거 구현

### DIFF
--- a/OnlyOne/Source/OnlyOne/Public/Game/POStageGameMode.h
+++ b/OnlyOne/Source/OnlyOne/Public/Game/POStageGameMode.h
@@ -75,6 +75,7 @@ protected:
 	void BeginGameEndPhase(APlayerState* InWinnerPS);
 	void CompactAlivePlayers();
 	void TryDecideWinner();
+	void NotifySpecialVictory(APlayerState* WinnerPS);
 	void WipeAllAIsOnStage();
 	bool ShouldEnterSpectatorOnJoin() const;
 	void EnterSpectatorForMidJoin(APlayerController* PC);


### PR DESCRIPTION
# Pull Request

## 주요 변경사항
- 특수 승리 트리거 기능 추가
- 
- 

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #
- Related to #

## 테스트 방법
1.  스테이지 입장 후 RoundEnd 페이즈로 전환될 때까지 진행합니다. 
2.  RoundEnd 진입 후 10초가 지나면 특수 승리 트리거가 자동 실행되는지 로그로 확인합니다. 
3.  이후 기존 GameEnd → 로비 이동 흐름이 정상적으로 이어지는지 확인합니다.

## 📷 스크린샷 (선택사항)
<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

## ⚠️ 주의사항
<!-- 리뷰어가 특별히 확인해야 할 부분이나 주의사항이 있다면 작성해주세요 -->

## 📋 체크리스트
<!-- PR 제출 전 확인사항 -->
- [x] 코드가 프로젝트의 스타일 가이드를 따르고 있습니다
- [x] 자체 검토를 수행했습니다
- [x] 불필요한 주석과 테스트 용 코드를 제거했습니다
- [x] 모든 테스트가 통과합니다

## 📝 추가 정보
<!-- 기타 리뷰어에게 전달하고 싶은 내용이 있다면 작성해주세요 -->
임시 테스트 코드는 merge 전에 제거하고 진행할 예정입니다.
